### PR TITLE
fix: update brace-expansion

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,13 +6,7 @@ settings:
 
 overrides:
   '@tootallnate/once@<2.0.1': ^2.0.1
-  body-parser@<1.20.6: ^1.20.6
-  brace-expansion@<1.1.16: ^1.1.16
   brace-expansion@<=5.0.7: ^5.0.8
-  brace-expansion@>=2.0.0 <2.1.2: ^2.1.2
-  fast-uri@>=3.0.0 <3.1.3: ^3.1.3
-  fast-uri@>=3.0.0 <=3.1.3: ^3.1.4
-  js-yaml@>=4.0.0 <4.3.0: ^4.3.0
   nth-check@<2.0.1: ^2.0.1
   postcss@<7.0.36: ^7.0.36
   postcss@<8.4.31: ^8.4.31
@@ -21,7 +15,6 @@ overrides:
   postcss@<=8.5.17: ^8.5.18
   serialize-javascript@<=7.0.2: ^7.0.3
   serialize-javascript@>=5.0.0 <7.0.5: ^7.0.5
-  shell-quote@<=1.8.4: ^1.8.5
   svgo@>=1.0.0 <2.8.3: ^2.8.3
   underscore@<=1.13.7: ^1.13.8
   uuid@<11.1.1: ^11.1.1
@@ -2057,9 +2050,6 @@ packages:
   babel-preset-react-app@10.1.0:
     resolution: {integrity: sha512-f9B1xMdnkCIqe+2dHrJsoQFRz7reChaAHE/65SdaykPklQqhme2WaC08oD3is77x9ff98/9EazAKFDZv5rFEQg==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -2094,9 +2084,6 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
-
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -8603,8 +8590,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.9.5: {}
@@ -8648,10 +8633,6 @@ snapshots:
       multicast-dns: 7.2.5
 
   boolbase@1.0.0: {}
-
-  brace-expansion@2.1.2:
-    dependencies:
-      balanced-match: 1.0.2
 
   brace-expansion@5.0.8:
     dependencies:
@@ -9291,7 +9272,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       has-proto: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       internal-slot: 1.1.0
       is-array-buffer: 3.0.5
       is-callable: 1.2.7
@@ -9358,11 +9339,11 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   es-shim-unscopables@1.1.0:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   es-to-primitive@1.3.0:
     dependencies:
@@ -9453,7 +9434,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
-      hasown: 2.0.2
+      hasown: 2.0.4
       is-core-module: 2.16.1
       is-glob: 4.0.3
       minimatch: 3.1.5
@@ -9492,7 +9473,7 @@ snapshots:
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
       eslint: 8.57.1
-      hasown: 2.0.2
+      hasown: 2.0.4
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
       minimatch: 3.1.5
@@ -9514,7 +9495,7 @@ snapshots:
       es-iterator-helpers: 1.2.1
       eslint: 8.57.1
       estraverse: 5.3.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       jsx-ast-utils: 3.3.5
       minimatch: 3.1.5
       object.entries: 1.1.9
@@ -9858,7 +9839,7 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       functions-have-names: 1.2.3
-      hasown: 2.0.2
+      hasown: 2.0.4
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
@@ -10305,7 +10286,7 @@ snapshots:
       call-bound: 1.0.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   is-regexp@1.0.0: {}
 
@@ -11120,7 +11101,7 @@ snapshots:
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,27 +11,14 @@ minimumReleaseAgeExclude:
   - serialize-javascript@7.0.5
   - uuid@11.1.1
   - webpack-dev-server@5.2.5
-  - brace-expansion@2.1.2
-  - brace-expansion@1.1.16
-  - js-yaml@4.3.0
-  - shell-quote@1.8.5
   - webpack-dev-server@5.2.6
-  - body-parser@1.20.6
   - svgo@2.8.3
-  - fast-uri@3.1.4
-  - fast-uri@3.1.3
   - postcss@8.5.12
   - postcss@8.5.18
   - brace-expansion@5.0.8
 overrides:
   '@tootallnate/once@<2.0.1': ^2.0.1
-  body-parser@<1.20.6: ^1.20.6
-  brace-expansion@<1.1.16: ^1.1.16
   brace-expansion@<=5.0.7: ^5.0.8
-  brace-expansion@>=2.0.0 <2.1.2: ^2.1.2
-  fast-uri@>=3.0.0 <3.1.3: ^3.1.3
-  fast-uri@>=3.0.0 <=3.1.3: ^3.1.4
-  js-yaml@>=4.0.0 <4.3.0: ^4.3.0
   nth-check@<2.0.1: ^2.0.1
   postcss@<7.0.36: ^7.0.36
   postcss@<8.4.31: ^8.4.31
@@ -40,7 +27,6 @@ overrides:
   postcss@<=8.5.17: ^8.5.18
   serialize-javascript@<=7.0.2: ^7.0.3
   serialize-javascript@>=5.0.0 <7.0.5: ^7.0.5
-  shell-quote@<=1.8.4: ^1.8.5
   svgo@>=1.0.0 <2.8.3: ^2.8.3
   underscore@<=1.13.7: ^1.13.8
   uuid@<11.1.1: ^11.1.1


### PR DESCRIPTION
Automated fixes for Dependabot security alerts.

## Updated packages
- brace-expansion: 2.1.2 -> 5.0.8

## Changes
Applied `pnpm audit --fix override` to resolve vulnerabilities
- Updated vulnerable packages to patched versions

## Security
Resolves 1 open Dependabot security alert.